### PR TITLE
fix: update link paths to relative URLs in post listings

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,7 @@
 <ul>
     {{ range where .Site.RegularPages "Section" "posts" }}
     <li>
-        <a href="{{ .Permalink }}">{{ .Title }}</a> - {{ .Date.Format "2006-01-02" }}
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a> - {{ .Date.Format "2006-01-02" }}
     </li>
     {{ end }}
 </ul>


### PR DESCRIPTION
Switched from absolute to relative permalinks in index.html to ensure more flexible navigation and better support for different environments (clearnet/.onion). This change prevents broken links in environments where the site domain may differ.